### PR TITLE
Empty object with newline

### DIFF
--- a/README_empty-object-with-newline.md
+++ b/README_empty-object-with-newline.md
@@ -1,0 +1,154 @@
+# empty-object-with-newline check and formatter
+
+In Shopify theme development, there is a GitHub bot which pulls in changes in GitHub repos.
+Sadly it formats .json files in a non standard way. Hence, every empty object get's a newline, which doesn't not conform to standard formatting.
+This creates then a new commit in the branch, which is pushed back into the origin repo. Which needs to be pulled to be able to push again. It's creating a cycle.
+
+Hence, I created the formatting option --empty-object-with-newline to conform to the Shopify .json formatting to prevent commit pollution.
+
+Sadly, this was not added as my pull request got declined. Hence, I kept the for up.
+
+## Synch upstream changes
+
+This Claude 3 Opus conversation gives the solution on how to merge in the upstream changes.
+
+### Prompt 1
+
+I have forked a github repo and added some commits to the main branch. Sadly, they didn't get merged with my pull request.
+
+I would like to move the last 4 commits now in a branch, to be able to update from the upstream repo
+
+### Response 1
+
+Here are the steps to move your last 4 commits from the main branch to a new branch:
+
+1. Make sure you're on the main branch:
+
+```bash
+git checkout main
+```
+
+2. Create a new branch and switch to it, e.g., named "feature-branch":
+
+```bash
+git checkout -b feature-branch
+```
+
+3. Move the main branch back by 4 commits, keeping the changes in your current branch:
+
+```bash
+git branch -f main HEAD~4
+```
+
+This effectively moves the main branch back by 4 commits, while your current branch (feature-branch) retains the commits.
+
+4. Push the updated main branch to your forked repository (assuming your remote is named "origin"):
+
+```bash
+git push origin main --force
+```
+
+Note: Using --force is necessary because you're rewriting the history of the main branch. Make sure you're aware of the implications and that it's safe to do so.
+
+5. Your feature-branch now contains the last 4 commits. You can push this branch to your forked repository:
+
+```bash
+git push origin feature-branch
+```
+
+After these steps, your main branch will be synchronized with the upstream repository, and your last 4 commits will be in the feature-branch.
+
+To update your forked repository with the latest changes from the upstream repository, you can do the following:
+
+1. Add the upstream repository as a remote (if you haven't already):
+
+```bash
+git remote add upstream <UPSTREAM_REPO_URL>
+```
+
+2. Fetch the latest changes from the upstream repository:
+
+```bash
+git fetch upstream
+```
+
+3. Merge the upstream changes into your main branch:
+
+```bash
+git checkout main
+git merge upstream/main
+```
+
+4. Push the updated main branch to your forked repository:
+
+```bash
+git push origin main
+```
+
+Now your forked repository's main branch will be up to date with the upstream repository, and you can work on your feature-branch separately.
+
+### Prompt 2
+
+I followed the instructions,but did the update of the repo from the upstream repo with the github online functionality, which worked fine.
+
+Now I created a pull request on github, which has merge conflicts.
+
+How can I resolve them locally?
+
+### Response 2
+
+To resolve merge conflicts locally for a pull request, you can follow these steps:
+
+1. Ensure that your local main branch is up to date with the upstream repository:
+
+```bash
+git checkout main
+git fetch upstream
+git merge upstream/main
+```
+
+2. Fetch the changes from your forked repository (assuming your remote is named "origin"):
+
+```
+git fetch origin
+```
+
+3. Check out the branch that has the merge conflicts (in this case, "feature-branch"):
+
+```
+git checkout feature-branch
+```
+
+4. Merge the main branch into your feature-branch:
+
+```
+git merge main
+```
+
+Git will highlight the files with merge conflicts.
+
+5. Open the conflicting files in a text editor and look for the conflict markers (`<<<<<<<`, `=======`, `>>>>>>>`). Resolve the conflicts by manually editing the files, deciding which changes to keep from your branch and which changes to keep from the main branch.
+
+6. After resolving the conflicts, remove the conflict markers and save the files.
+
+7. Stage the resolved files:
+
+```
+git add <resolved-file1> <resolved-file2> ...
+```
+
+8. Commit the changes:
+
+```
+git commit -m "Resolve merge conflicts"
+```
+
+9. Push the updated feature-branch to your forked repository:
+
+```
+git push origin feature-branch
+```
+
+After pushing the changes, the pull request on GitHub should automatically update, and the merge conflicts should be resolved.
+
+If you encounter any issues or have further questions, feel free to ask!

--- a/pre_commit_hooks/pretty_format_json.py
+++ b/pre_commit_hooks/pretty_format_json.py
@@ -2,16 +2,17 @@ from __future__ import annotations
 
 import argparse
 import json
-import sys
 import re
-
+import sys
 from difflib import unified_diff
 from typing import Mapping
 from typing import Sequence
 
+
 def _insert_linebreaks(json_str) -> str:
     # (?P<spaces>\s*) seems to capture the \n. Hence, there is no need for it in the substitution string
-    return re.sub(r'\n(?P<spaces>\s*)(?P<json_key>.*): {}(?P<delim>,??)', '\n\g<spaces>\g<json_key>: {\n\g<spaces>}\g<delim>', json_str)
+    return re.sub(r'\n(?P<spaces>\s*)(?P<json_key>.*): {}(?P<delim>,??)', '\n\\g<spaces>\\g<json_key>: {\n\\g<spaces>}\\g<delim>', json_str)
+
 
 def _get_pretty_format(
         contents: str,
@@ -126,7 +127,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             pretty_contents = _get_pretty_format(
                 contents, args.indent, ensure_ascii=not args.no_ensure_ascii,
                 sort_keys=not args.no_sort_keys, top_keys=args.top_keys,
-                empty_object_with_newline=args.empty_object_with_newline
+                empty_object_with_newline=args.empty_object_with_newline,
             )
         except ValueError:
             print(
@@ -144,7 +145,6 @@ def main(argv: Sequence[str] | None = None) -> int:
             else:
                 diff_output = get_diff(contents, pretty_contents, json_file)
                 sys.stdout.buffer.write(diff_output.encode())
-
 
     return status
 

--- a/pre_commit_hooks/pretty_format_json.py
+++ b/pre_commit_hooks/pretty_format_json.py
@@ -8,11 +8,14 @@ from collections.abc import Mapping
 from collections.abc import Sequence
 from difflib import unified_diff
 
+
 def _insert_linebreaks(json_str: str) -> str:
     return re.sub(
-        r'\n(?P<spaces>\s*)(?P<json_key>.*): {}(?P<delim>,??)', 
-        '\n\g<spaces>\g<json_key>: {\n\g<spaces>}\g<delim>', 
-        json_str)
+        r'\n(?P<spaces>\s*)(?P<json_key>.*): {}(?P<delim>,??)',
+        '\n\\g<spaces>\\g<json_key>: {\n\\g<spaces>}\\g<delim>',
+        json_str,
+    )
+
 
 def _get_pretty_format(
         contents: str,
@@ -110,8 +113,8 @@ def main(argv: Sequence[str] | None = None) -> int:
         action='store_true',
         dest='empty_object_with_newline',
         default=False,
-        help='Format empty JSON objects to have a linebreak, ' \
-            + 'also activates --no-sort-keys',
+        help='Format empty JSON objects to have a linebreak, ' +
+        'also activates --no-sort-keys',
     )
     parser.add_argument('filenames', nargs='*', help='Filenames to fix')
     args = parser.parse_args(argv)
@@ -146,7 +149,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                     diff_output = get_diff(
                         contents,
                         pretty_contents,
-                        json_file
+                        json_file,
                     )
                     sys.stdout.buffer.write(diff_output.encode())
 

--- a/pre_commit_hooks/pretty_format_json.py
+++ b/pre_commit_hooks/pretty_format_json.py
@@ -9,9 +9,11 @@ from difflib import unified_diff
 from typing import Mapping
 from typing import Sequence
 
-def _insert_linebreaks(json_str) -> str:
-    # (?P<spaces>\s*) seems to capture the \n. Hence, there is no need for it in the substitution string
-    return re.sub(r'\n(?P<spaces>\s*)(?P<json_key>.*): {}(?P<delim>,??)', '\n\g<spaces>\g<json_key>: {\n\g<spaces>}\g<delim>', json_str)
+def _insert_linebreaks(json_str: str) -> str:
+    return re.sub(
+        r'\n(?P<spaces>\s*)(?P<json_key>.*): {}(?P<delim>,??)', 
+        '\n\g<spaces>\g<json_key>: {\n\g<spaces>}\g<delim>', 
+        json_str)
 
 def _get_pretty_format(
         contents: str,
@@ -109,7 +111,8 @@ def main(argv: Sequence[str] | None = None) -> int:
         action='store_true',
         dest='empty_object_with_newline',
         default=False,
-        help='Format empty JSON objects to have a linebreak, also activates --no-sort-keys',
+        help='Format empty JSON objects to have a linebreak, ' \
+            + 'also activates --no-sort-keys',
     )
     parser.add_argument('filenames', nargs='*', help='Filenames to fix')
     args = parser.parse_args(argv)

--- a/pre_commit_hooks/pretty_format_json.py
+++ b/pre_commit_hooks/pretty_format_json.py
@@ -141,7 +141,11 @@ def main(argv: Sequence[str] | None = None) -> int:
                 if args.autofix:
                     _autofix(json_file, pretty_contents)
                     if args.empty_object_with_newline:
+                        # When using --empty-object-with-newline with --autofix,
+                        # we want to return success after fixing
                         status = 0
+                    else:
+                        status = 1
                 else:
                     diff_output = get_diff(
                         contents,
@@ -149,8 +153,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                         json_file
                     )
                     sys.stdout.buffer.write(diff_output.encode())
-
-                status = 1
+                    status = 1
 
     return status
 

--- a/testing/resources/empty_object_json_multiline.json
+++ b/testing/resources/empty_object_json_multiline.json
@@ -1,0 +1,17 @@
+{
+  "empty": {
+  },
+  "inhabited": {
+    "person": {
+      "name": "Roger",
+      "nested_empty_with_comma": {
+      },
+      "array": [
+        {
+          "nested_empty_in_array": {
+          }
+        }
+      ]
+    }
+  }
+}

--- a/testing/resources/empty_object_json_sameline.json
+++ b/testing/resources/empty_object_json_sameline.json
@@ -1,0 +1,14 @@
+{
+  "empty": {},
+  "inhabited": {
+    "person": {
+      "name": "Roger",
+      "nested_empty_with_comma": {},
+      "array": [
+        {
+          "nested_empty_in_array": {}
+        }
+      ]
+    }
+  }
+}

--- a/tests/pretty_format_json_test.py
+++ b/tests/pretty_format_json_test.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
+import filecmp
 import os
 import shutil
 
 import pytest
-import filecmp
 
 from pre_commit_hooks.pretty_format_json import main
 from pre_commit_hooks.pretty_format_json import parse_num_to_int
@@ -142,13 +142,13 @@ def test_diffing_output(capsys):
 
 def test_empty_object_with_newline(tmpdir):
     # same line objects shoud trigger with --empty-object-with-newline switch
-    sameline = get_resource_path("empty_object_json_sameline.json")
-    ret = main(["--empty-object-with-newline", str(sameline)])
+    sameline = get_resource_path('empty_object_json_sameline.json')
+    ret = main(['--empty-object-with-newline', str(sameline)])
     assert ret == 1
 
-    multiline = get_resource_path("empty_object_json_multiline.json")
+    multiline = get_resource_path('empty_object_json_multiline.json')
     to_be_formatted_sameline = tmpdir.join(
-        "not_pretty_formatted_empty_object_json_sameline.json"
+        'not_pretty_formatted_empty_object_json_sameline.json',
     )
     shutil.copyfile(str(sameline), str(to_be_formatted_sameline))
 
@@ -158,12 +158,12 @@ def test_empty_object_with_newline(tmpdir):
 
     # now launch the autofix with empty object with newline support on that file
     ret = main(
-        ["--autofix", "--empty-object-with-newline", str(to_be_formatted_sameline)]
+        ['--autofix', '--empty-object-with-newline', str(to_be_formatted_sameline)],
     )
     # it should have formatted it and don't raise an error code
     assert ret == 0
 
     # file was formatted (shouldn't trigger linter with --empty-object-with-newline switch)
-    ret = main(["--empty-object-with-newline", str(to_be_formatted_sameline)])
+    ret = main(['--empty-object-with-newline', str(to_be_formatted_sameline)])
     assert ret == 0
     assert filecmp.cmp(to_be_formatted_sameline, multiline)

--- a/tests/pretty_format_json_test.py
+++ b/tests/pretty_format_json_test.py
@@ -146,24 +146,29 @@ def test_empty_object_with_newline(tmpdir):
     ret = main(["--empty-object-with-newline", str(sameline)])
     assert ret == 1
 
+    # a template to be compared against.
     multiline = get_resource_path("empty_object_json_multiline.json")
-    to_be_formatted_sameline = tmpdir.join(
-        "not_pretty_formatted_empty_object_json_sameline.json"
-    )
-    shutil.copyfile(str(sameline), str(to_be_formatted_sameline))
 
     # file has empty object with newline => expect fail with default settings
     ret = main([str(multiline)])
     assert ret == 1
 
-    # now launch the autofix with empty object with newline support on that file
+    # launch the autofix with empty object with newline support on that file
+    to_be_formatted_sameline = tmpdir.join(
+        "not_pretty_formatted_empty_object_json_sameline.json"
+    )
+    shutil.copyfile(str(sameline), str(to_be_formatted_sameline))
     ret = main(
-        ["--autofix", "--empty-object-with-newline", str(to_be_formatted_sameline)]
+        ["--autofix",
+        "--empty-object-with-newline",
+        str(to_be_formatted_sameline)]
     )
     # it should have formatted it and don't raise an error code
+    # to not stop the the commit
     assert ret == 0
 
-    # file was formatted (shouldn't trigger linter with --empty-object-with-newline switch)
+    # file was formatted (shouldn't trigger linter with 
+    # --empty-object-with-newline switch)
     ret = main(["--empty-object-with-newline", str(to_be_formatted_sameline)])
     assert ret == 0
     assert filecmp.cmp(to_be_formatted_sameline, multiline)

--- a/tests/pretty_format_json_test.py
+++ b/tests/pretty_format_json_test.py
@@ -165,7 +165,7 @@ def test_empty_object_with_newline(tmpdir):
     assert ret == 1
 
     # a template to be compared against.
-    multiline = get_resource_path("empty_object_json_multiline.json")
+    multiline = get_resource_path('empty_object_json_multiline.json')
 
     # file has empty object with newline => expect fail with default settings
     ret = main([str(multiline)])
@@ -173,20 +173,22 @@ def test_empty_object_with_newline(tmpdir):
 
     # launch the autofix with empty object with newline support on that file
     to_be_formatted_sameline = tmpdir.join(
-        "not_pretty_formatted_empty_object_json_sameline.json"
+        'not_pretty_formatted_empty_object_json_sameline.json',
     )
     shutil.copyfile(str(sameline), str(to_be_formatted_sameline))
     ret = main(
-        ["--autofix",
-        "--empty-object-with-newline",
-        str(to_be_formatted_sameline)]
+        [
+            '--autofix',
+            '--empty-object-with-newline',
+            str(to_be_formatted_sameline),
+        ],
     )
     # it should have formatted it and don't raise an error code
     # to not stop the the commit
     assert ret == 0
 
-    # file was formatted (shouldn't trigger linter with 
+    # file was formatted (shouldn't trigger linter with
     # --empty-object-with-newline switch)
-    ret = main(["--empty-object-with-newline", str(to_be_formatted_sameline)])
+    ret = main(['--empty-object-with-newline', str(to_be_formatted_sameline)])
     assert ret == 0
     assert filecmp.cmp(to_be_formatted_sameline, multiline)


### PR DESCRIPTION
For Shopify themes, they format the JSON objects differently, as everybody else for empty objects.
There is no way to prevent it. Hence, I added support to check and format it their way.